### PR TITLE
Fix crashing on binder

### DIFF
--- a/interactive-ml-demo.imjoy.html
+++ b/interactive-ml-demo.imjoy.html
@@ -14,7 +14,7 @@
   "api_version": "0.1.8",
   "env": "",
   "permissions": [],
-  "requirements": ["repo:https://github.com/imjoy-team/imjoy-interactive-segmentation", "pip:-r imjoy-interactive-segmentation/requirements.txt"],
+  "requirements": ["repo:https://github.com/imjoy-team/imjoy-interactive-segmentation", "cmd: pip install -r imjoy-interactive-segmentation/requirements.txt --no-cache-dir"],
   "dependencies": []
 }
 </config>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ read_roi
 palettable
 descartes
 imageio
-numpy==1.18.0
+numpy>=1.18.0
 tensorflow==2.3.1
 albumentations
 ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ geojson
 read_roi
 palettable
 descartes
-geojson
 imageio
 numpy==1.18.0
 tensorflow==2.3.1


### PR DESCRIPTION
Binder has only 2GB memory and when installing pytorch 1.7, it exceed that limit and cause the kernel to restart.

This PR fixes this error by adding `--no-cache-dir` to the pip install command:
```
pip install -r imjoy-interactive-segmentation/requirements.txt --no-cache-dir
```