### PR TITLE
Pass model_config instead of a model instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,20 @@ Create a jupyter notebook and run the followin code in a cell:
 from imjoy_plugin import start_interactive_segmentation
 from models.interactive_cellpose import CellPoseInteractiveModel
 
-model = CellPoseInteractiveModel('./data/hpa_dataset_v2/__models__',
+model = CellPoseInteractiveModel(model_dir='./data/hpa_dataset_v2/__models__',
                                  channels=[2, 3],
                                  style_on=0,
-                                 default_diameter=100)
+                                 default_diameter=100,
+                                 use_gpu=True,
+                                 pretrained_model=False,
+                                 resume=True)
 
 start_interactive_segmentation(model,
                                "./data/hpa_dataset_v2",
                                ["microtubules.png", "er.png", "nuclei.png"],
                                mask_type="labels",
                                object_name="cell",
-                               scale_factor=1.0,
-                               resume=True)
+                               scale_factor=1.0)
 ```
 
 We also made a python notebook to illustrate the whole interactive training workflow in **tutorial.ipynb**

--- a/Tutorial.ipynb
+++ b/Tutorial.ipynb
@@ -68,20 +68,22 @@
    "outputs": [],
    "source": [
     "from imjoy_plugin import start_interactive_segmentation\n",
-    "from models.interactive_cellpose import CellPoseInteractiveModel\n",
     "\n",
-    "model = CellPoseInteractiveModel('./data/hpa_dataset_v2/__models__',\n",
-    "                                 pretrained_model=False, # \n",
-    "                                 channels=[2, 3],\n",
-    "                                 style_on=0,\n",
-    "                                 default_diameter=100)\n",
+    "model_config = dict( type=\"cellpose\",\n",
+    "                     model_dir='./data/hpa_dataset_v2/__models__',\n",
+    "                     use_gpu=True,\n",
+    "                     channels=[2, 3],\n",
+    "                     style_on=0,\n",
+    "                     batch_size=1,\n",
+    "                     default_diameter=100,\n",
+    "                     pretrained_model=False,\n",
+    "                     resume=False)\n",
     "\n",
-    "start_interactive_segmentation(model,\n",
+    "start_interactive_segmentation(model_config,\n",
     "                               \"./data/hpa_dataset_v2\",\n",
     "                               [\"microtubules.png\", \"er.png\", \"nuclei.png\"],\n",
     "                               object_name=\"cell\",\n",
-    "                               scale_factor=1.0,\n",
-    "                               resume=True)"
+    "                               scale_factor=1.0)"
    ]
   },
   {
@@ -101,15 +103,6 @@
    "source": [
     "from interactive_trainer import InteractiveTrainer\n",
     "trainer = InteractiveTrainer.get_instance()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trainer.start()"
    ]
   },
   {

--- a/imjoy_plugin.py
+++ b/imjoy_plugin.py
@@ -406,9 +406,10 @@ class ImJoyPlugin:
         self.last_iteration = None
 
         async def refresh():
+            error = self._trainer.get_error(clear=True)
             if len(self._trainer.reports) > 0:
                 v = self._trainer.reports[-1]
-                error = self._trainer.get_error()
+
                 if v["iteration"] != self.last_iteration:
                     title = f'Iteration {v["iteration"]}, Loss: {v["loss"]:.4f}'
                     if not self._trainer.training_enabled:
@@ -424,11 +425,11 @@ class ImJoyPlugin:
                         await chart.set_title(f"Error: {error}")
                     else:
                         await chart.set_title("Starting...")
-                else:
-                    if error:
-                        await chart.set_title(f"Error: {error}")
-                        await api.error(f"Error: {error}")
-                        # await api.showMessage(f"Error: {error}")
+
+            if error:
+                await chart.set_title(f"Error: {error}")
+                await api.error(f"Error: {error}")
+                await api.showMessage(f"Error: {error}")
             self.viewer.set_timeout(refresh, 2000)
 
         self.viewer.set_timeout(refresh, 2000)

--- a/interactive-ml-demo.imjoy.html
+++ b/interactive-ml-demo.imjoy.html
@@ -27,7 +27,6 @@ import os
 from download_example_dataset import download_with_url
 from imjoy import api
 from imjoy_plugin import start_interactive_segmentation
-from models.interactive_cellpose import CellPoseInteractiveModel
 
 # download exmaple dataset
 os.makedirs("data", exist_ok=True)
@@ -43,15 +42,19 @@ else:
         + dataset_path
     )
 
-model = CellPoseInteractiveModel('./data/hpa_dataset_v2/__models__',
-                                channels=[2, 3],
-                                style_on=0,
-                                default_diameter=100)
-start_interactive_segmentation(model,
+model_config = dict(type="cellpose",
+                    model_dir='./data/hpa_dataset_v2/__models__',
+                    channels=[2, 3],
+                    style_on=0,
+                    default_diameter=100,
+                    batch_size=1,
+                    use_gpu=True,
+                    pretrained_model=False,
+                    resume=True)
+
+start_interactive_segmentation(model_config,
             "./data/hpa_dataset_v2",
             ["microtubules.png", "er.png", "nuclei.png"],
             object_name="cell",
-            scale_factor=1.0,
-            batch_size=1,
-            resume=True)
+            scale_factor=1.0)
 </script>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,7 +1,7 @@
 class InteractiveModel:
     """Interactive model interface"""
 
-    def __init__(self, model_path, *args, **kwargs):
+    def __init__(self, **kwargs):
         """load and initialize the model"""
         pass
 
@@ -16,6 +16,20 @@ class InteractiveModel:
         ------------------
         array [width, height, channel]
             the transformed label image
+        """
+        raise NotImplementedError
+
+    def get_config(self):
+        """augment the images and labels
+        Parameters
+        --------------
+        None
+
+        Returns
+        ------------------
+        config: dict
+            a dictionary contains the following keys:
+            1) `batch_size` the batch size for training
         """
         raise NotImplementedError
 

--- a/tests/test_cellpose.py
+++ b/tests/test_cellpose.py
@@ -39,7 +39,11 @@ geojson_to_label(annotation_file, save_as="_masks.png")
 X = (read_multi_channel_image(folder, channels, rescale=1.0)).transpose(1, 2, 0)
 
 model = CellPoseInteractiveModel(
-    "./data/hpa_dataset_v2/__models__", style_on=0, default_diameter=100
+    model_dir="./data/hpa_dataset_v2/__models__",
+    style_on=0,
+    default_diameter=100,
+    resume=False,
+    pretrained_model=False,
 )
 
 
@@ -73,7 +77,11 @@ def test_train():
         rescale=1.0,
     )
     images, labels, image_names, test_images, test_labels, image_names_test = output
-    model.train((np.stack(images, axis=0), np.stack(labels, axis=0)), (np.stack(test_images, axis=0), np.stack(test_labels, axis=0)), iterations=1)
+    model.train(
+        (np.stack(images, axis=0), np.stack(labels, axis=0)),
+        (np.stack(test_images, axis=0), np.stack(test_labels, axis=0)),
+        iterations=1,
+    )
 
 
 def test_train_steps():

--- a/tests/test_interactive_trainer.py
+++ b/tests/test_interactive_trainer.py
@@ -9,23 +9,23 @@ from imageio import imwrite
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from interactive_trainer import InteractiveTrainer
-from models.interactive_cellpose import CellPoseInteractiveModel
 
-model = CellPoseInteractiveModel(
-    "./data/hpa_dataset_v2/__models__",
+model_config = dict(
+    type="cellpose",
+    model_dir="./data/hpa_dataset_v2/__models__",
     use_gpu=False,
     channels=[2, 3],
     style_on=0,
     default_diameter=100,
+    pretrained_model=False,
+    resume=False,
 )
 trainer = InteractiveTrainer.get_instance(
-    model,
+    model_config,
     "./data/hpa_dataset_v2",
     ["microtubules.png", "er.png", "nuclei.png"],
     object_name="cell",
     scale_factor=1.0,
-    batch_size=1,
-    resume=False,
 )
 
 


### PR DESCRIPTION
To make sure we can run the trainer instance multiple times, we pass a configuration dictionary instead of a model instance.